### PR TITLE
Add hashbang interpreter line

### DIFF
--- a/pass.py
+++ b/pass.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 #-------------------------------------------------------------------------------
 # Name:        pass.py
 # Purpose:     parses password store (pass) for use in ansible


### PR DESCRIPTION
to fix the following error when using this module with Ansible 2.1:

```
localhost | FAILED! => {
    "failed": true,
    "msg": "module (pass) is missing interpreter line"
}
```
